### PR TITLE
Fixes .cdsinit Load Error

### DIFF
--- a/virtue/Project.ils
+++ b/virtue/Project.ils
@@ -19,7 +19,9 @@ Project = let(((project_packages makeTable("virtue project packages")))
       when(isFile(filepath)
         config_filepath = filepath)
     )
-    unless(config_filepath
+    if(config_filepath then
+      package_table['project] = read_project_config(config_filepath)
+    else
       warn(strcat(
         "Could not read the pyproject.toml or skill-project.toml file!\n
         Please make sure it is located in the same directory as the\n
@@ -27,7 +29,6 @@ Project = let(((project_packages makeTable("virtue project packages")))
       ))
     )
 
-    package_table['project] = read_project_config(config_filepath)
     package_table['project]['project_root_path] = project_init_dir_path
     register_project(project_package)
     project_package

--- a/virtue/api.py
+++ b/virtue/api.py
@@ -71,7 +71,7 @@ def _install_env_cdsinit_script(filepath: Path) -> None:
     with filepath.open("w") as file:
         file.write((
             "printf(\"\\n---------------------------------------------------"
-            "--------------\n\")"
+            "--------------\\n\")\n"
             "printf(\"Initializing Virtue skill environment\\n\")\n"
             f"printf(\"  loading {filepath}\\n\")\n\n"
             "let((init_files)\n"


### PR DESCRIPTION
Fixes #23, anerror when loading a Virtue SKILL environment .cdsinit file. generated using the `virtue install` command.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?
**Note:** Please include unit tests and integration tests that cover the update.  The unit tests should be fast (ms) and the integration tests should be representative of real use cases.

## Checklist:

- [x] I linked the issues it addresses
  - a pull request should have 1-3 linked issues
- [ ] I have assigned at least 1 reviewer
- [x] I have applied appropriate labels
- [ ] I have assigned it to a milestone
- [ ] I have assigned it to a project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
